### PR TITLE
feat: Automatic semver increment selection

### DIFF
--- a/cz_version_bump/__init__.py
+++ b/cz_version_bump/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections import OrderedDict
 from textwrap import dedent
 
 try:
@@ -9,7 +10,7 @@ try:
 except ImportError:
     from string import Template
 
-from commitizen import git
+from commitizen import defaults, git
 from commitizen.cz.base import BaseCommitizen
 from commitizen.defaults import Questions
 
@@ -20,6 +21,25 @@ issue_id_pattern = re.compile(r"\s+\(#(\d+)\)$")
 
 
 class MeltanoCommitizen(BaseCommitizen):
+    bump_pattern = defaults.bump_pattern
+    bump_map = defaults.bump_map
+    bump_pattern = r"^(feat|fix|refactor|perf|break|docs|ci|chore|style|revert|test|build)(\(.+\))?(!)?"
+    bump_map = OrderedDict(
+        (
+            (r"^break", defaults.MINOR),  # A major release can only be created explicitly.
+            (r"^feat", defaults.MINOR),
+            (r"^fix", defaults.PATCH),
+            (r"^refactor", defaults.PATCH),
+            (r"^perf", defaults.PATCH),
+            (r"^docs", defaults.PATCH),
+            (r"^ci", defaults.PATCH),
+            (r"^chore", defaults.PATCH),
+            (r"^style", defaults.PATCH),
+            (r"^revert", defaults.PATCH),
+            (r"^test", defaults.PATCH),
+            (r"^build", defaults.PATCH),
+        )
+    )
     commit_parser = r"^(?P<change_type>feat|fix|refactor|perf|break|docs)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?:\s(?P<message>.*)?"
     schema_pattern = r"(feat|fix|refactor|perf|break|docs|ci|chore|style|revert|test|build)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?:(\s.*)"
     schema = dedent(

--- a/cz_version_bump/__init__.py
+++ b/cz_version_bump/__init__.py
@@ -26,7 +26,10 @@ class MeltanoCommitizen(BaseCommitizen):
     bump_pattern = r"^(feat|fix|refactor|perf|break|docs|ci|chore|style|revert|test|build)(\(.+\))?(!)?"
     bump_map = OrderedDict(
         (
-            (r"^break", defaults.MINOR),  # A major release can only be created explicitly.
+            (
+                r"^break",
+                defaults.MINOR,
+            ),  # A major release can only be created explicitly.
             (r"^feat", defaults.MINOR),
             (r"^fix", defaults.PATCH),
             (r"^refactor", defaults.PATCH),


### PR DESCRIPTION
If the semver increment is provided explicitly, this has no effect. Otherwise, all of the commits going into the release will have their messages checked. If any start with "break" or "feat", then it'll increment the minor version. If all of the commit messages start with other supported semantic PR types, it'll default to a patch release.

Commit messages that start with anything other than a supported semantic PR type are ignored. If no commits are found that match the `bump_map` rules, a minor version bump is performed by default.

A major version bump is never performed automatically. It must be selected explicitly.

Closes #4